### PR TITLE
Disable security context by default and let the cluster handle it

### DIFF
--- a/charts/hawkbit/values.yaml
+++ b/charts/hawkbit/values.yaml
@@ -155,6 +155,8 @@ mysql:
   master:
     persistence:
       enabled: true
+    securityContext:
+      enabled: false
   volumePermissions:
     enabled: false
   db:
@@ -171,6 +173,8 @@ rabbitmq:
   enabled: true
   persistence:
     enabled: true
+  securityContext:
+    enabled: false
   volumePermissions:
     enabled: true
   rabbitmq:


### PR DESCRIPTION
This change disables the provided security context and the lets the cluster assign a random user ID.